### PR TITLE
Fixed the incorrect dataset name in the Shells markdown.

### DIFF
--- a/Shells.md
+++ b/Shells.md
@@ -65,7 +65,7 @@ Essential commands:
 ## Practice: Importing a CSV file
 
 * Download the Product Hunt Data `wget https://s3-us-west-2.amazonaws.com/producthunt-downloads/ph-export--2016-04-01.tar.gz`
-* Extract dataset: `tar -zxvf ph-export--2016.tar.gz`
+* Extract dataset: `tar -zxvf ph-export--2016-04-01.tar.gz`
 * Change into product-hunt folder.
 * Inspect the file contents: `head posts--2016-04-01_14-36-24-UTC.csv`
 * Estimate number of contents: `cat posts--2016-04-01_14-36-24-UTC.csv | wc -l`


### PR DESCRIPTION
Error is thrown when we specify the incorrect tar file name while unzipping. This has been changed to the original file name as was downloaded from the AWS S3 link specified.